### PR TITLE
feat: header comments can't start after empty line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parse attachment mark before tuple (`attached TUPLE`) [#14]
 
 ### Changed
+- Don't match a `(header_comment)`if there is an empty line before it,
+  it will be matched as a simple `(comment)`. [#16]
 
 ### Removed
 
@@ -29,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 [#14]: https://github.com/imustafin/tree-sitter-eiffel/pull/14
+[#16]: https://github.com/imustafin/tree-sitter-eiffel/pull/16
 
 [unreleased]: https://github.com/imustafin/tree-sitter-eiffel/compare/v1.0.0...HEAD
 [v1.0.0]: https://github.com/imustafin/tree-sitter-eiffel/compare/3dbff72823c37277ac5db345258d9c5c0beb3a77...v1.0.0

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -25,7 +25,7 @@
       }
     },
     "header_comment": {
-      "type": "TOKEN",
+      "type": "IMMEDIATE_TOKEN",
       "content": {
         "type": "PREC",
         "value": 2,
@@ -33,8 +33,11 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "PATTERN",
-              "value": "--"
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "PATTERN",
+                "value": "[ \\t]*\\r?\\n?[ \\t]*--"
+              }
             },
             {
               "type": "IMMEDIATE_TOKEN",
@@ -53,6 +56,19 @@
           ]
         }
       }
+    },
+    "_header_comment": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "header_comment"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "comment"
+        }
+      ]
     },
     "class_declaration": {
       "type": "SEQ",
@@ -325,7 +341,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "header_comment"
+              "name": "_header_comment"
             },
             {
               "type": "BLANK"
@@ -524,7 +540,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "header_comment"
+              "name": "_header_comment"
             },
             {
               "type": "BLANK"
@@ -1136,7 +1152,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "header_comment"
+              "name": "_header_comment"
             },
             {
               "type": "BLANK"
@@ -1252,7 +1268,7 @@
                     "members": [
                       {
                         "type": "SYMBOL",
-                        "name": "header_comment"
+                        "name": "_header_comment"
                       },
                       {
                         "type": "BLANK"
@@ -1273,7 +1289,7 @@
                     "members": [
                       {
                         "type": "SYMBOL",
-                        "name": "header_comment"
+                        "name": "_header_comment"
                       },
                       {
                         "type": "BLANK"
@@ -1314,7 +1330,7 @@
                     "members": [
                       {
                         "type": "SYMBOL",
-                        "name": "header_comment"
+                        "name": "_header_comment"
                       },
                       {
                         "type": "BLANK"

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1031,6 +1031,10 @@
           "named": true
         },
         {
+          "type": "comment",
+          "named": true
+        },
+        {
           "type": "header_comment",
           "named": true
         },
@@ -1543,6 +1547,10 @@
           "named": true
         },
         {
+          "type": "comment",
+          "named": true
+        },
+        {
           "type": "header_comment",
           "named": true
         }
@@ -1571,6 +1579,10 @@
         },
         {
           "type": "class_type",
+          "named": true
+        },
+        {
+          "type": "comment",
           "named": true
         },
         {
@@ -2154,6 +2166,10 @@
       "types": [
         {
           "type": "clients",
+          "named": true
+        },
+        {
+          "type": "comment",
           "named": true
         },
         {

--- a/test/corpus/feature.txt
+++ b/test/corpus/feature.txt
@@ -81,6 +81,28 @@ end
     (comment)))
 
 ===
+Normal comment after empty line after feature keyword
+===
+class A
+feature
+
+-- Normal comment
+-- Normal comment again
+
+feature
+
+  -- Normal comment
+end
+---
+(source_file
+  (class_declaration
+    (class_name)
+    (feature_clause
+      (comment))
+    (comment)
+    (feature_clause
+      (comment))))
+===
 Feature declaration header comment
 ===
 class A


### PR DESCRIPTION
Header comments can't start after an empty line. If there is an empty line, then it should be a normal comment:
```eiffel
class A
feature

	-- Normal comment
end
```

With this implementation, the `(comment)` will be a child of the described node, not its sibling as usual. So,`(feature_declaration (comment))` instead of `(feature_declaration) (comment)`. I think it is not a big deal, so we can keep it this way.