### PR TITLE
feat: add neovim compatible indent and highlight queries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Parse attachment mark before tuple (`attached TUPLE`) [#14]
+- Add indent queries compatible with [neovim](https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md). [#17]
 
 ### Changed
 - Don't match a `(header_comment)`if there is an empty line before it,
   it will be matched as a simple `(comment)`. [#16]
+- Differentiate in `(conditional_expression)` the `(else_part_expression)`. [#17]
+- Extend highlight queries compatible with [neovim](https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md). [#17]
 
 ### Removed
 
@@ -32,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#14]: https://github.com/imustafin/tree-sitter-eiffel/pull/14
 [#16]: https://github.com/imustafin/tree-sitter-eiffel/pull/16
+[#17]: https://github.com/imustafin/tree-sitter-eiffel/pull/17
 
 [unreleased]: https://github.com/imustafin/tree-sitter-eiffel/compare/v1.0.0...HEAD
 [v1.0.0]: https://github.com/imustafin/tree-sitter-eiffel/compare/3dbff72823c37277ac5db345258d9c5c0beb3a77...v1.0.0

--- a/grammar.js
+++ b/grammar.js
@@ -590,8 +590,7 @@ module.exports = grammar({
       'if',
       $.then_part_expression,
       repeat(seq('elseif', $.then_part_expression)),
-      'else',
-      $.expression,
+      $.else_part_expression,
       'end'
     ),
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,17 +1,54 @@
-[
- "class"
- "feature"
- "do"
- "end"
+["class"  "feature" "end" "do" "alias" "convert"
+ "invariant" "across" "as" "loop" "check"
+ "if" "attached" "then" "else" "elseif"
+ "inspect" "when" "then"
+ "note" "local" "create" "require" "ensure"
+ "from" "variant" "until" "and" "and then" "or" "or else" "xor"
+ "detachable" "old" "∀" "∃" "¦" "all" "some"
+ "implies" "once" (unary_not) "attribute" "agent" "like" "export" "all"
 ] @keyword
 
+[ "frozen" "deferred" "inherit" "redefine" "undefine" "rename" "select" ] @keyword.modifier
+
+(conditional ["if" "elseif" "end"] @keyword.conditional)
+(else_part ["else"] @keyword.conditional)
+(then_part ["then"] @keyword.conditional)
+(conditional_expression ["if" "else" "elseif" "end"] @keyword.conditional)
+(else_part_expression ["else"] @keyword.conditional)
+(then_part_expression ["then"] @keyword.conditional)
+
+(quantifier_loop ["∀" "∃" ":" "¦"] @keyword.repeat)
+(quantifier_loop_body ["all" "some"] @keyword.repeat)
+(iteration ["across" "as"] @keyword.repeat)
+(initialization ["from"] @keyword.repeat)
+(exit_condition ["until"] @keyword.repeat)
+(loop (invariant "invariant" @keyword.repeat))
+(loop ["⟳" ":" "¦" "⟲"]@keyword.repeat)
+(loop "end" @keyword.repeat)
+(loop_body ["loop"] @keyword.repeat)
+(variant ["variant"] @keyword.repeat)
+
+[["(" ")" "[" "]" "<<" ">>"]] @punctuation.bracket
+[["," ":"]] @punctuation.delimiter
+[[(unary) ":=" (binary_caret) (binary_mul_div) (binary_plus_minus)
+  (binary_comparison) (binary_and) (binary_or) (binary_implies)
+  (comparison)]] @operator
+[(result)] @variable.builtin
+(anchored (call (_) @variable))
+[(verbatim_string) (basic_manifest_string)] @string
+[(integer_constant) (real_constant)] @constant.numeric
+[(boolean_constant)] @constant.boolean
+[(void) (current)] @constant
+(extended_feature_name (identifier) @function.method)
+
+(iteration (identifier) @variable)
+(quantifier_loop (identifier) @variable)
+(entity_declaration_group (identifier) @variable)
 [
  (class_name)
 ] @type
 
 (extended_feature_name (identifier) @function)
 
-[
- (comment)
- (header_comment)
-] @comment
+[ (comment) ] @comment
+[(header_comment)] @comment.documentation

--- a/queries/indents.scm
+++ b/queries/indents.scm
@@ -1,13 +1,28 @@
 [
   (class_declaration)
-  (attribute_or_routine)
   (feature_declaration)
-] @indent
+  (feature_body)
+  (notes)
+  (precondition)
+  (local_declarations)
+  (postcondition)
+  (check)
+  (initialization)
+  (iteration)
+  (exit_condition)
+  (loop_body)
+  (variant)
+  (quantifier_loop)
+  (then_part)
+  (else_part)
+  (then_part_expression)
+  (else_part_expression)
+  (multi_branch)
+] @indent.begin
+(loop (invariant) @indent.begin)
 
-[
-  (internal)
-] @indent @extend
-
-;[                                                                                                                                                                                                                                                       │
-;  (comment)                                                                                                                                                                                                                                             │
-;] @indent.always (set! "scope" "all")   
+(check "end" @indent.branch)
+(class_declaration "end" @indent.branch)
+(feature_clause "feature" @indent.branch)
+(inheritance "inherit" @indent.branch)
+(creation_clause "create" @indent.branch)

--- a/queries/textobjects.scm
+++ b/queries/textobjects.scm
@@ -1,5 +1,5 @@
 [
-  (comment)+ 
+  (comment)+
   (header_comment)+
 ] @comment.around
 [
@@ -7,6 +7,7 @@
   (header_comment)
 ] @comment.inside
 (formal_arguments) @parameter.around
+(entity_declaration_group) @parameter.inside
 (attribute_or_routine) @function.around
 (feature_body) @function.inside
 (class_declaration) @class.around

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2631,12 +2631,8 @@
           }
         },
         {
-          "type": "STRING",
-          "value": "else"
-        },
-        {
           "type": "SYMBOL",
-          "name": "expression"
+          "name": "else_part_expression"
         },
         {
           "type": "STRING",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -789,7 +789,7 @@
       "required": true,
       "types": [
         {
-          "type": "expression",
+          "type": "else_part_expression",
           "named": true
         },
         {

--- a/test/corpus/body.txt
+++ b/test/corpus/body.txt
@@ -264,7 +264,8 @@ end
                     (then_part_expression
                       (expression (call (unqualified_call (identifier))))
                       (expression (call (unqualified_call (identifier)))))
-                      (expression (call (unqualified_call (identifier)))))))))))))))
+                    (else_part_expression
+                      (expression (call (unqualified_call (identifier))))))))))))))))
 
 ===
 Body. Multi-branch


### PR DESCRIPTION
Add indent and highlight queries in compatibility with [neovim requirements](https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md).
`conditional_expression` has now a child `else_part_expression` to mimic the behavior of `conditional_instruction`. 